### PR TITLE
🗂️ separate pages for figures, embeds, xrefs

### DIFF
--- a/content/embeds.md
+++ b/content/embeds.md
@@ -1,0 +1,18 @@
+# Embeds
+
+MyST This supports embedding of notebook content and other files. The following are some examples using the embed directive. 
+
+## A Matplotlib Output
+
+:::{embed} #fig-matplotlib
+:::
+
+## A Plotly Figure
+
+:::{embed} #fig-plotly-output
+:::
+
+## A Bokeh Figure
+
+:::{embed} #fig-bokeh
+:::

--- a/content/external.md
+++ b/content/external.md
@@ -1,0 +1,14 @@
+# External content
+
+MyST Supports cross-referencing into external content in order to create figures and embeds. External content could be in a different version of the AST and would need special handling.
+
+
+## An External Figure!
+
+![](xref:guide#img:altair-horsepower)
+
+
+## An External Embed!
+
+:::{embed} xref:guide#img:altair-horsepower
+:::

--- a/content/figures.md
+++ b/content/figures.md
@@ -1,0 +1,18 @@
+# Figures
+
+MyST supports using notebook outputs inside figures, This page contains some examples. 
+
+## A Matplotlib Figure
+
+![](#fig-matplotlib)
+
+## A Plotly Figure
+
+:::{figure} #fig-plotly-output
+A plotly figure
+:::
+
+## A Bokeh Figure
+
+![](#fig-bokeh)
+

--- a/content/index.md
+++ b/content/index.md
@@ -1,20 +1,8 @@
 # Plots
 
-MyST supports embedding plots from other pages and site! Here are some such plots, such as [](#fig-plotly-output) and [](#fig-bokeh-output). See them below!
+MyST supports embedding plots from other pages and site! Here are some such plots, such as [](#fig-plotly-output) and [](#fig-bokeh-output).
 
-## A Plotly Figure
+* [](./figures.md)
+* [](./embeds.md)
+* [](./external.md)
 
-:::{embed} #fig-plotly-output
-:::
-
-## A Bokeh Figure
-
-![](#fig-bokeh)
-
-## A Matplotlib Figure
-
-![](#fig-matplotlib)
-
-## An External Figure!
-
-![](xref:guide#img:altair-horsepower)

--- a/myst.yml
+++ b/myst.yml
@@ -7,6 +7,9 @@ project:
     guide: https://mystmd.org/guide
   toc:
     - file: content/index.md
+    - file: content/figures.md
+    - file: content/embeds.md
+    - file: content/external.md
     - file: content/bokeh.md
     - file: content/plotly.md
     - file: content/matplotlib.md


### PR DESCRIPTION
I've moved some of the different directive types up to independent pages. This helps make it easier to repeat using each type of output in a different directive. We can have figures for Plotly, Matplotlib, etc., and then repeat again separately with embed directives because they are different code paths. 

The x-refs I've separated out into a different page because they were easily just crashing the site, for example making changes and it looks like they need special handling. This just makes testing a little bit easier without having to comment out directives in the main index.md. 